### PR TITLE
Fix deserialization errors

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -46,12 +46,12 @@ impl Action {
         Ok(body)
     }
 
-    async fn perform(&self, payload: ActionPayload) -> Result<String, Box<dyn std::error::Error>> {
+    async fn perform(&self, payload: ActionPayload) -> Result<(), Box<dyn std::error::Error>> {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().push("subtitles");
         let response = self.client.patch(url).json(&payload).send().await?;
-        let res_body = response.text().await?;
-        Ok(res_body)
+        response.error_for_status()?;
+        Ok(())
     }
 
     async fn process_episode_subtitle(&self, series: &TVShow, episode: Episode) {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -57,7 +57,6 @@ impl Action {
     async fn process_episode_subtitle(&self, series: &TVShow, episode: Episode) {
         for subtitle in episode.subtitles {
             if !subtitle.is_valid() {
-                println!("Skipping invalid subtitle: {}", subtitle.audio_language_item.name);
                 continue;
             }
 
@@ -93,7 +92,6 @@ impl Action {
     async fn process_movie_subtitle(&self, movie: Movie) {
         for subtitle in movie.subtitles {
             if !subtitle.is_valid() {
-                println!("Skipping invalid subtitle: {}", subtitle.audio_language_item.name);
                 continue;
             }
             let payload = ActionPayload {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -72,7 +72,7 @@ impl Action {
                         self.action.to_string(), 
                         subtitle.audio_language_item.name,
                         episode.title, 
-                        series.common_attributes.title, 
+                        series.title, 
                     ));
                 }
                 Err(err) => {
@@ -80,7 +80,7 @@ impl Action {
                         self.action.to_string(), 
                         subtitle.audio_language_item.name,
                         episode.title, 
-                        series.common_attributes.title, 
+                        series.title, 
                         err,
                     ));
                 }
@@ -106,7 +106,7 @@ impl Action {
                         "Successfully performed action `{}` on {} subtitle of movie `{}`",
                         self.action.to_string(),
                         subtitle.audio_language_item.name,
-                        movie.common_attributes.title,
+                        movie.title,
                     ));
                 }
                 Err(err) => {
@@ -114,7 +114,7 @@ impl Action {
                         format!("Error performing action `{}` on {} subtitle of movie `{}` due to error {}", 
                         self.action.to_string(), 
                         subtitle.audio_language_item.name,
-                        movie.common_attributes.title, 
+                        movie.title, 
                         err,
                     ));
                 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -56,13 +56,15 @@ impl Action {
 
     async fn process_episode_subtitle(&self, series: &TVShow, episode: Episode) {
         for subtitle in episode.subtitles {
-            if subtitle.path.is_none() {
-                return;
+            if !subtitle.is_valid() {
+                println!("Skipping invalid subtitle: {}", subtitle.audio_language_item.name);
+                continue;
             }
+
             let payload = ActionPayload {
                 id: episode.sonarr_episode_id,
                 media_type: String::from("episode"),
-                language: subtitle.audio_language_item.code2,
+                language: subtitle.audio_language_item.code2.unwrap(),
                 path: subtitle.path.unwrap(),
                 action: self.action.clone(),
             };
@@ -90,13 +92,14 @@ impl Action {
 
     async fn process_movie_subtitle(&self, movie: Movie) {
         for subtitle in movie.subtitles {
-            if subtitle.path.is_none() {
+            if !subtitle.is_valid() {
+                println!("Skipping invalid subtitle: {}", subtitle.audio_language_item.name);
                 continue;
             }
             let payload = ActionPayload {
                 id: movie.radarr_id,
                 media_type: String::from("movie"),
-                language: subtitle.audio_language_item.code2,
+                language: subtitle.audio_language_item.code2.unwrap(),
                 path: subtitle.path.unwrap(),
                 action: self.action.clone(),
             };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use reqwest::{header, Client, Url};
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, str::FromStr};
 
-use crate::{actions::Action, data_types::app_config::AppConfig};
+use crate::{actions::Action, connection::check_health, data_types::app_config::AppConfig};
 
 #[derive(Parser)]
 #[command(name = "Bazarr Bulk Actions CLI")]
@@ -50,6 +50,8 @@ impl Commands {
         let client = Client::builder().default_headers(headers).build()?;
         let base_url = format!("{}://{}:{}/api", config.protocol, config.host, config.port);
         let url = Url::from_str(&base_url)?;
+        check_health(&client, &url).await;
+
         let mut action = Action::new(client, url);
         match self {
             Commands::Movies { subcommand } => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,28 @@
+use std::process::exit;
+
+use reqwest::{Client, Url};
+
+pub async fn check_health(client: &Client, url: &Url) {
+    let mut url = url.clone();
+    url.path_segments_mut().unwrap().push("system/status");
+    let response = client.get(url).send().await;
+    if let Ok(res) = response {
+        if res.status().is_success() {
+            println!("Bazarr API is healthy.");
+        } else if res.status() == reqwest::StatusCode::UNAUTHORIZED {
+            eprintln!("Unauthorized! Please verify that the correct Bazarr API key has been set in the configuration file.");
+            exit(1);
+        } else {
+            eprintln!(
+                "Error while connecting to Bazarr. Response: {}",
+                res.text().await.unwrap()
+            );
+            println!("Attempting to continue anyway...")
+        }
+    } else {
+        println!(
+            "Error while connecting to Bazarr. Please verify that the protocol, host, and port provided in the configuration file are correct."
+        );
+        exit(1);
+    }
+}

--- a/src/data_types/response.rs
+++ b/src/data_types/response.rs
@@ -31,8 +31,7 @@ pub struct Episode {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AudioLanguageItem {
     pub name: String,
-    pub code2: String,
-    pub code3: String,
+    pub code2: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,4 +39,10 @@ pub struct Subtitle {
     pub path: Option<String>,
     #[serde(flatten)]
     pub audio_language_item: AudioLanguageItem,
+}
+
+impl Subtitle {
+    pub fn is_valid(&self) -> bool {
+        self.path.is_some() && self.audio_language_item.code2.is_some()
+    }
 }

--- a/src/data_types/response.rs
+++ b/src/data_types/response.rs
@@ -10,55 +10,21 @@ pub struct Movie {
     pub subtitles: Vec<Subtitle>,
     #[serde(rename = "radarrId")]
     pub radarr_id: u32,
-    #[serde(flatten)]
-    pub common_attributes: CommonMediaAttributes,
+    pub title: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TVShow {
-    #[serde(rename = "episodeFileCount")]
-    pub episode_file_count: u32,
-    #[serde(rename = "episodeMissingCount")]
-    pub episode_missing_count: u32,
-    #[serde(rename = "seriesType")]
-    pub series_type: String,
     #[serde(rename = "sonarrSeriesId")]
     pub sonarr_series_id: u32,
-    #[serde(rename = "tvdbId")]
-    pub tvdb_id: u32,
-    #[serde(flatten)]
-    pub common_attributes: CommonMediaAttributes,
+    pub title: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Episode {
-    pub audio_language: Vec<AudioLanguageItem>,
-    pub episode: u32,
-    pub monitored: bool,
-    pub path: String,
-    pub season: u32,
     #[serde(rename = "sonarrEpisodeId")]
     pub sonarr_episode_id: u32,
     pub subtitles: Vec<Subtitle>,
-    pub title: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CommonMediaAttributes {
-    pub title: String,
-    #[serde(rename = "alternativeTitles")]
-    pub alternative_titles: Vec<String>,
-    pub audio_language: Vec<AudioLanguageItem>,
-    pub fanart: String,
-    #[serde(rename = "imdbId")]
-    pub imdb_id: String,
-    pub monitored: bool,
-    pub overview: String,
-    pub path: String,
-    pub poster: String,
-    #[serde(rename = "profileId")]
-    pub profile_id: u32,
-    pub year: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -71,9 +37,6 @@ pub struct AudioLanguageItem {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Subtitle {
     pub path: Option<String>,
-    pub forced: bool,
-    pub hi: bool,
-    pub file_size: Option<u32>,
     #[serde(flatten)]
     pub audio_language_item: AudioLanguageItem,
 }

--- a/src/data_types/response.rs
+++ b/src/data_types/response.rs
@@ -25,6 +25,7 @@ pub struct Episode {
     #[serde(rename = "sonarrEpisodeId")]
     pub sonarr_episode_id: u32,
     pub subtitles: Vec<Subtitle>,
+    pub title: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod actions;
 mod cli;
 mod data_types;
+mod connection;
 
 use clap::Parser;
 use cli::Cli;


### PR DESCRIPTION
Multiple users have reported deserialization errors when attempting to run bazarr-bulk. This PR removes unused fields from response structs and ensures that nullable fields coming from Bazarr's API are handled correctly, thus making the whole thing less error-prone.