### PR TITLE
Add offset and limit arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A CLI tool for performing actions in bulk on Bazarr movies and tv shows.
 List of supported actions:
+
 - sync
 - ocr-fixes
 - common-fixes
@@ -85,24 +86,26 @@ bb --help
 2. Extract the archive
 3. Run bb.exe
 
-
 ## Usage
+
 1. Create a JSON config file based on the template [file](./examples/config.json).
 2. Run `bb --config your-config.json` [movies|tv-shows] [ACTION]
 
 ### General help
+
 ```bash
 bb --help
+# Performs bulk operations on subtitles of movies and tv shows using Bazarr's API
 
 Usage: bb --config <FILE> <COMMAND>
 
 Commands:
-  movies    perform operations on movies
-  tv-shows  perform operations on tv shows
+  movies    Perform operations on movies
+  tv-shows  Perform operations on tv shows
   help      Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config <FILE>
+  -c, --config <FILE>  Path to the JSON configuration file
   -h, --help           Print help
 ```
 
@@ -110,43 +113,46 @@ Options:
 
 ```bash
 bb movies --help
-# perform operations on movies
+# Perform operations on movies
 
-Usage: bb --config <FILE> movies <COMMAND>
+Usage: bb --config <FILE> movies [OPTIONS] <COMMAND>
 
 Commands:
-  sync                     sync all
-  ocr-fixes                perform OCR fixes on all
-  common-fixes             perform common fixes on all
-  remove-hearing-impaired  remove hearing impaired tags from subtitles
-  remove-style-tags        remove style tags from subtitles
-  fix-uppercase            fix uppercase subtitles
-  reverse-rtl              reverse RTL directioned subtitles
+  sync                     Sync all
+  ocr-fixes                Perform OCR fixes
+  common-fixes             Perform common fixes
+  remove-hearing-impaired  Remove hearing impaired tags from subtitles
+  remove-style-tags        Remove style tags from subtitles
+  fix-uppercase            Fix uppercase subtitles
+  reverse-rtl              Reverse RTL directioned subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+      --offset <OFFSET>  Skip N records [default: 0]
+      --limit <LIMIT>    Limit to N records [default: unlimited]
+  -h, --help             Print help
 ```
-
 
 ### TV Shows
 
 ```bash
 bb tv-shows --help
-# perform operations on tv shows
+# Perform operations on tv shows
 
-Usage: bb --config <FILE> tv-shows <COMMAND>
+Usage: bb --config <FILE> tv-shows [OPTIONS] <COMMAND>
 
 Commands:
-  sync                     sync all
-  ocr-fixes                perform OCR fixes on all
-  common-fixes             perform common fixes on all
-  remove-hearing-impaired  remove hearing impaired tags from subtitles
-  remove-style-tags        remove style tags from subtitles
-  fix-uppercase            fix uppercase subtitles
-  reverse-rtl              reverse RTL directioned subtitles
+  sync                     Sync all
+  ocr-fixes                Perform OCR fixes
+  common-fixes             Perform common fixes
+  remove-hearing-impaired  Remove hearing impaired tags from subtitles
+  remove-style-tags        Remove style tags from subtitles
+  fix-uppercase            Fix uppercase subtitles
+  reverse-rtl              Reverse RTL directioned subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+      --offset <OFFSET>  Skip N records [default: 0]
+      --limit <LIMIT>    Limit to N records [default: unlimited]
+  -h, --help             Print help
 ```

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -16,6 +16,8 @@ pub struct Action {
     pub client: Client,
     pub base_url: Url,
     pub action: ActionCommands,
+    pub offset: u32,
+    pub limit: Option<u32>,
     pub pb: ProgressBar,
 }
 
@@ -31,15 +33,24 @@ impl Action {
             client,
             base_url,
             action: ActionCommands::Sync,
+            offset: 0,
+            limit: None,
             pb,
         }
     }
 
-    async fn get_all<T>(&self, url: Url) -> Result<PaginatedResponse<T>, Box<dyn std::error::Error>>
+    async fn get_all<T>(&self, mut url: Url, limit_records: bool) -> Result<PaginatedResponse<T>, Box<dyn std::error::Error>>
     where
         T: DeserializeOwned,
         T: Debug,
     {
+        if limit_records {
+            let length: i32 = match self.limit {
+                Some(val) => val as i32,
+                None => -1
+            };
+            url.query_pairs_mut().append_pair("length", &length.to_string()).append_pair("start", &self.offset.to_string());
+        }
         let req = self.client.get(url);
         let res = req.send().await?;
         let body: PaginatedResponse<T> = res.json().await?;
@@ -126,7 +137,7 @@ impl Action {
     pub async fn movies(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().push("movies");
-        let response = self.get_all::<Movie>(url).await?;
+        let response = self.get_all::<Movie>(url, true).await?;
         self.pb.set_length(response.data.len() as u64);
         for movie in response.data {
             self.process_movie_subtitle(movie).await;
@@ -142,7 +153,7 @@ impl Action {
     pub async fn tv_shows(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().push("series");
-        let response = self.get_all::<TVShow>(url.clone()).await?;
+        let response = self.get_all::<TVShow>(url.clone(), true).await?;
         let num_series = response.data.len();
         self.pb.set_length(num_series as u64);
         url.path_segments_mut().unwrap().pop().push("episodes");
@@ -150,7 +161,7 @@ impl Action {
             let query_param = format!("seriesid[]={}", series.sonarr_series_id);
             let mut new_url = url.clone();
             new_url.set_query(Some(&query_param));
-            let response = self.get_all::<Episode>(new_url).await?;
+            let response = self.get_all::<Episode>(new_url, false).await?;
             for episode in response.data {
                 self.process_episode_subtitle(&series, episode).await;
             }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -138,7 +138,13 @@ impl Action {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().push("movies");
         let response = self.get_all::<Movie>(url, true).await?;
-        self.pb.set_length(response.data.len() as u64);
+        let num_movies: u64 = response.data.len() as u64;
+        if num_movies == 0 {
+            self.pb.finish_with_message("No movies found");
+            return Ok(());
+        }
+
+        self.pb.set_length(num_movies);
         for movie in response.data {
             self.process_movie_subtitle(movie).await;
             self.pb.inc(1);
@@ -154,8 +160,13 @@ impl Action {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().push("series");
         let response = self.get_all::<TVShow>(url.clone(), true).await?;
-        let num_series = response.data.len();
-        self.pb.set_length(num_series as u64);
+        let num_series: u64= response.data.len() as u64;
+        if num_series == 0 {
+            self.pb.finish_with_message("No tv shows found");
+            return Ok(());
+        }
+
+        self.pb.set_length(num_series);
         url.path_segments_mut().unwrap().pop().push("episodes");
         for series in response.data {
             let query_param = format!("seriesid[]={}", series.sonarr_series_id);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ use crate::{actions::Action, connection::check_health, data_types::app_config::A
 #[command(author = "Mateo Radman <radmanmateo@gmail.com>")]
 #[command(about = "Performs bulk operations on subtitles of movies and tv shows using Bazarr's API", long_about = None)]
 pub struct Cli {
-    // Path to the JSON configuration file
+    /// Path to the JSON configuration file
     #[arg(short, long, value_name = "FILE")]
     pub config: PathBuf,
 
@@ -26,22 +26,22 @@ impl Cli {
 
 #[derive(clap::Args)]
 pub struct CommonArgs {
-    // skip N records
+    /// Skip N records
     #[arg(long, default_value_t = 0)]
     offset: u32,
-    // process N records
+    /// Limit to N records [default: unlimited]
     #[arg(long)]
     limit: Option<u32>,
-    // list available actions
+    /// List available actions
     #[command(subcommand)]
     subcommand: ActionCommands,
 }
 
 #[derive(Subcommand)]
 pub enum Commands {
-    // perform operations on movies
+    /// Perform operations on movies
     Movies(CommonArgs),
-    /// perform operations on tv shows
+    /// Perform operations on tv shows
     TVShows(CommonArgs),
 }
 
@@ -77,19 +77,19 @@ impl Commands {
 
 #[derive(Subcommand, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 pub enum ActionCommands {
-    /// sync all
+    /// Sync all
     Sync,
-    /// perform OCR fixes on all
+    /// Perform OCR fixes
     OCRFixes,
-    /// perform common fixes on all
+    /// Perform common fixes
     CommonFixes,
-    /// remove hearing impaired tags from subtitles
+    /// Remove hearing impaired tags from subtitles
     RemoveHearingImpaired,
-    /// remove style tags from subtitles
+    /// Remove style tags from subtitles
     RemoveStyleTags,
-    /// fix uppercase subtitles
+    /// Fix uppercase subtitles
     FixUppercase,
-    /// reverse RTL directioned subtitles
+    /// Reverse RTL directioned subtitles
     ReverseRTL,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,20 +24,25 @@ impl Cli {
     }
 }
 
+#[derive(clap::Args)]
+pub struct CommonArgs {
+    // skip N records
+    #[arg(long, default_value_t = 0)]
+    offset: u32,
+    // process N records
+    #[arg(long)]
+    limit: Option<u32>,
+    // list available actions
+    #[command(subcommand)]
+    subcommand: ActionCommands,
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
-    /// perform operations on movies
-    Movies {
-        /// list available actions
-        #[command(subcommand)]
-        subcommand: ActionCommands,
-    },
+    // perform operations on movies
+    Movies(CommonArgs),
     /// perform operations on tv shows
-    TVShows {
-        /// list available actions
-        #[command(subcommand)]
-        subcommand: ActionCommands,
-    },
+    TVShows(CommonArgs),
 }
 
 impl Commands {
@@ -54,12 +59,16 @@ impl Commands {
 
         let mut action = Action::new(client, url);
         match self {
-            Commands::Movies { subcommand } => {
-                action.action = subcommand;
+            Commands::Movies(c) => {
+                action.action = c.subcommand;
+                action.limit = c.limit;
+                action.offset = c.offset;
                 action.movies().await
             }
-            Commands::TVShows { subcommand } => {
-                action.action = subcommand;
+            Commands::TVShows(c) => {
+                action.action = c.subcommand;
+                action.limit = c.limit;
+                action.offset = c.offset;
                 action.tv_shows().await
             }
         }


### PR DESCRIPTION
This PR adds --offset and --limit arguments to the CLI. It allows users to process their movies/tv-shows in batches by skipping or limiting a certain number of records.