### PR TITLE
fix(#7): add "base" key in config to specify base url

### DIFF
--- a/examples/base_url_config.json
+++ b/examples/base_url_config.json
@@ -1,0 +1,7 @@
+{
+  "host": "0.0.0.0",
+  "protocol": "http",
+  "port": "6767",
+  "base": "/bazarr",
+  "apiKey": "<YOUR_API_KEY>"
+}

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,6 +1,8 @@
 {
+  "_comment": "This is a sample configuration file. Port and Base URL are optional fields",
   "host": "0.0.0.0",
   "protocol": "http",
+  "apiKey": "<YOUR_API_KEY>",
   "port": "6767",
-  "apiKey": "<YOUR_API_KEY>"
+  "baseUrl": "bazarr"
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,9 @@
 use clap::{Parser, Subcommand};
-use reqwest::{header, Client, Url};
+use reqwest::{header, Client};
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, str::FromStr, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use crate::{actions::Action, connection::check_health, data_types::app_config::AppConfig};
 
@@ -79,8 +79,7 @@ impl Commands {
         let client = ClientBuilder::new(reqwest_client)
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .build();
-        let base_url = format!("{}://{}:{}{}/api", config.protocol, config.host, config.port, config.base);
-        let url = Url::from_str(&base_url)?;
+        let url = config.construct_url();
         check_health(&client, &url).await;
 
         let mut action = Action::new(client, url);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,7 +79,7 @@ impl Commands {
         let client = ClientBuilder::new(reqwest_client)
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .build();
-        let base_url = format!("{}://{}:{}/api", config.protocol, config.host, config.port);
+        let base_url = format!("{}://{}:{}{}/api", config.protocol, config.host, config.port, config.base);
         let url = Url::from_str(&base_url)?;
         check_health(&client, &url).await;
 

--- a/src/data_types/app_config.rs
+++ b/src/data_types/app_config.rs
@@ -25,6 +25,7 @@ pub struct AppConfig {
     pub protocol: Protocol,
     pub host: String,
     pub port: String,
+    pub base: String,
     pub api_key: String,
 }
 
@@ -35,6 +36,7 @@ impl AppConfig {
             .set_default("host", "0.0.0.0")?
             .set_default("port", "6767")?
             .set_default("protocol", "http")?
+            .set_default("base", "")?
             .build()?;
 
         config.try_deserialize()

--- a/src/data_types/app_config.rs
+++ b/src/data_types/app_config.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use config::{Config, ConfigError, File, FileFormat};
+use reqwest::Url;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -24,8 +25,8 @@ impl fmt::Display for Protocol {
 pub struct AppConfig {
     pub protocol: Protocol,
     pub host: String,
-    pub port: String,
-    pub base: String,
+    pub port: Option<String>,
+    pub base_url: String,
     pub api_key: String,
 }
 
@@ -34,11 +35,30 @@ impl AppConfig {
         let config = Config::builder()
             .add_source(File::new(config_path, FileFormat::Json))
             .set_default("host", "0.0.0.0")?
-            .set_default("port", "6767")?
             .set_default("protocol", "http")?
-            .set_default("base", "")?
+            .set_default("baseUrl", "")?
             .build()?;
 
         config.try_deserialize()
+    }
+
+    pub fn construct_url(&self) -> Url {
+        let mut bazarr_url = format!("{}://{}", self.protocol, self.host);
+
+        if let Some(port) = &self.port {
+            bazarr_url = format!("{}:{}", bazarr_url, port);
+        }
+
+        // clean the base_url by removing leading and trailing slashes
+        let clean_base_url = self.base_url.trim_matches('/');
+
+        let mut url = Url::parse(&bazarr_url).unwrap();
+        url.path_segments_mut()
+            .unwrap()
+            .push(clean_base_url)
+            .push("api");
+
+        println!("Bazarr API URL: {}", url);
+        url
     }
 }


### PR DESCRIPTION
I tested this and it worked with the example I added in `./examples`.

If you feel like "base" is too vague feel free to change the name. It could be `base_url` but you already use that name elsewhere so I wasn't sure what to do with that.

I've never coded in rust before so I'm not sure if I needed to add this line:
```rust
.set_default("base", "")?
```
or is that already default?

Finally, it might be important to say somewhere that the leading slash in the base url is needed, or we could figure out a way to make it not needed. Not sure what the proper way to do this would be.