### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mateoradman/bazarr-bulk/security/code-scanning/4](https://github.com/mateoradman/bazarr-bulk/security/code-scanning/4)

To fix the issue, add a `permissions` block with minimal permissions required for this workflow. For most Rust CI jobs, `contents: read` is adequate—this allows necessary read access to repository contents, which is needed for code checkout and read-only operations, but does not grant write permissions. This block can be added at the top level (affecting all jobs unless overridden), or to individual jobs (such as the `test` job). The recommended way is to add it at the root of the workflow, directly after the `name` and before any `on`, `env`, or `jobs` blocks.

No imports or method changes are needed. The workflow file should be updated by inserting the following lines:

```yaml
permissions:
  contents: read
```

directly after the `name: Rust CI` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
