### PR TITLE
feat: add remove-emoji action

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -129,7 +129,9 @@ Available actions:
 - `common-fixes`
 - `remove-hearing-impaired`
 - `remove-style-tags`
+- `fix-uppercase`
 - `reverse-rtl`
+- `remove-emoji`
 
 ### Persistent Database
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN case "$TARGETARCH" in \
 RUN case "$TARGETARCH" in \
     "arm64") \
         if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
-            mkdir -p ~/.cargo && \
-            echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml && \
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml; \
+            mkdir -p $CARGO_HOME && \
+            echo '[target.aarch64-unknown-linux-gnu]' >> $CARGO_HOME/config.toml && \
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> $CARGO_HOME/config.toml; \
         fi \
         ;; \
     esac

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ List of supported actions:
 - common-fixes
 - remove-hearing-impaired
 - remove-style-tags
+- fix-uppercase
 - reverse-rtl
+- remove-emoji
 
 ## Installation
 
@@ -193,6 +195,7 @@ Commands:
   remove-style-tags        Remove style tags from subtitles
   fix-uppercase            Fix uppercase subtitles
   reverse-rtl              Reverse RTL directioned subtitles
+  remove-emoji             Remove emoji from subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -220,6 +223,7 @@ Commands:
   remove-style-tags        Remove style tags from subtitles
   fix-uppercase            Fix uppercase subtitles
   reverse-rtl              Reverse RTL directioned subtitles
+  remove-emoji             Remove emoji from subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -140,6 +140,8 @@ pub enum ActionCommands {
     FixUppercase,
     /// Reverse RTL directioned subtitles
     ReverseRTL,
+    /// Remove emoji from subtitles
+    RemoveEmoji,
 }
 
 #[allow(clippy::to_string_trait_impl)]
@@ -153,6 +155,7 @@ impl ToString for ActionCommands {
             ActionCommands::RemoveStyleTags => "remove_tags".to_string(),
             ActionCommands::FixUppercase => "fix_uppercase".to_string(),
             ActionCommands::ReverseRTL => "reverse_rtl".to_string(),
+            ActionCommands::RemoveEmoji => "emoji".to_string(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #59.

Adds the `remove-emoji` action to bazarr-bulk, exposing the emoji removal subtitle modification introduced in Bazarr core [commit 721a49d](https://github.com/morpheus65535/bazarr/commit/721a49d63db6d149ba792e5b3db02846a71d60d6) ([morpheus65535/bazarr#2987](https://github.com/morpheus65535/bazarr/issues/2987)).

- Adds `RemoveEmoji` variant to the `ActionCommands` enum, mapped to Bazarr API action string `"emoji"` — no other source files required changes; the existing action dispatch in `actions.rs` handles this generically via `ActionCommands::to_string()`
- Adds `remove-emoji` to all action listings in `README.md` and `DOCKER.md`; also corrects a pre-existing omission of `fix-uppercase` from the short action lists in both files (the CLI help blocks in README already had it correctly)
- Fixes a pre-existing arm64 cross-compilation bug in `Dockerfile` where the cargo cross-linker config was written to `~/.cargo/config.toml` instead of `$CARGO_HOME/config.toml` (the official Rust Docker image sets `CARGO_HOME=/usr/local/cargo`, so the linker override was never applied, causing arm64 builds to fail with a wrong-format ELF error)

## Files Changed

| File | Change |
|------|--------|
| `src/cli.rs` | Added `RemoveEmoji` variant to `ActionCommands` enum and `"emoji"` string mapping in `ToString` impl |
| `README.md` | Added `remove-emoji` to supported actions list and both Movies/TV Shows CLI help blocks; corrected pre-existing missing `fix-uppercase` in short list |
| `DOCKER.md` | Added `remove-emoji` to Available Actions list; corrected pre-existing missing `fix-uppercase` |
| `Dockerfile` | Fixed arm64 cross-linker config path: `~/.cargo` → `$CARGO_HOME` |

## Usage

```bash
# Remove emoji from all movie subtitles
bb --config config.json movies remove-emoji

# Remove emoji from English TV show subtitles, skipping already processed
bb --config config.json tv-shows --language en --skip-processed remove-emoji
```

## Tested on my UnRaid instance, screenshots here:

command: ["--config", "/config/config.json", "movies", "remove-emoji"]

<img width="449" height="245" alt="image" src="https://github.com/user-attachments/assets/5ebceb6a-c74e-4404-be61-192667d19244" />

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!