### PR TITLE
feat: make --skip-processed action-aware

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -129,7 +129,9 @@ Available actions:
 - `common-fixes`
 - `remove-hearing-impaired`
 - `remove-style-tags`
+- `fix-uppercase`
 - `reverse-rtl`
+- `remove-emoji`
 
 ### Persistent Database
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -47,11 +47,11 @@ docker run --rm \
   -v bazarr-bulk-data:/data \
   bazarr-bulk --config /config/config.json tv-shows ocr-fixes
 
-# Example: With skip-processed flag
+# Example: With skip-processed flag (tracked per action — ocr-fixes and common-fixes are independent)
 docker run --rm \
   -v "$(pwd)/config.json:/config/config.json:ro" \
   -v bazarr-bulk-data:/data \
-  bazarr-bulk --config /config/config.json movies sync --skip-processed
+  bazarr-bulk --config /config/config.json movies ocr-fixes --skip-processed
 ```
 
 ### 3. Using Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN case "$TARGETARCH" in \
 RUN case "$TARGETARCH" in \
     "arm64") \
         if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
-            mkdir -p ~/.cargo && \
-            echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml && \
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml; \
+            mkdir -p $CARGO_HOME && \
+            echo '[target.aarch64-unknown-linux-gnu]' >> $CARGO_HOME/config.toml && \
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> $CARGO_HOME/config.toml; \
         fi \
         ;; \
     esac

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Options:
       --ids <IDS>        Filter records by Sonarr/Radarr ID (comma-separated)
       --offset <OFFSET>  Skip N records (ignored if ids are specified) [default: skip none] [default: 0]
       --limit <LIMIT>    Limit to N records (ignored if ids are specified) [default: unlimited]
-      --skip-processed   Skip previously processed items (uses local database to track processed subtitles)
+      --skip-processed   Skip previously processed items for the current action (uses local database to track processed subtitles per action)
   -l, --language <LANGUAGE>  Filter subtitles by language code (e.g., en, es, fr)
   -h, --help             Print help
 ```
@@ -230,7 +230,7 @@ Options:
       --ids <IDS>        Filter records by Sonarr/Radarr ID (comma-separated)
       --offset <OFFSET>  Skip N records (ignored if ids are specified) [default: skip none] [default: 0]
       --limit <LIMIT>    Limit to N records (ignored if ids are specified) [default: unlimited]
-      --skip-processed   Skip previously processed items (uses local database to track processed subtitles)
+      --skip-processed   Skip previously processed items for the current action (uses local database to track processed subtitles per action)
   -l, --language <LANGUAGE>  Filter subtitles by language code (e.g., en, es, fr)
   -h, --help             Print help
 ```
@@ -276,4 +276,18 @@ bb --config config.json movies --ids 123,456,789 --language en sync
 ```bash
 bb --config config.json movies --language fr --skip-processed remove-hearing-impaired
 ```
+
+### Run multiple actions independently using skip-processed
+
+`--skip-processed` tracks each action separately, so running a second action will not skip items already processed by a different action:
+
+```bash
+# First pass: OCR fixes — marks each subtitle as processed for "ocr-fixes"
+bb --config config.json movies --skip-processed ocr-fixes
+
+# Second pass: common fixes — does NOT skip items from the ocr-fixes pass
+bb --config config.json movies --skip-processed common-fixes
+```
+
+> **Note:** If you have an existing database created before this change, you will see a one-time migration warning on startup. Existing records are preserved but will not count towards skip-processed checks under the new per-action scheme. Re-run each action once to rebuild the per-action processed history.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ List of supported actions:
 - common-fixes
 - remove-hearing-impaired
 - remove-style-tags
+- fix-uppercase
 - reverse-rtl
+- remove-emoji
 
 ## Installation
 
@@ -193,6 +195,7 @@ Commands:
   remove-style-tags        Remove style tags from subtitles
   fix-uppercase            Fix uppercase subtitles
   reverse-rtl              Reverse RTL directioned subtitles
+  remove-emoji             Remove emoji from subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:
@@ -220,6 +223,7 @@ Commands:
   remove-style-tags        Remove style tags from subtitles
   fix-uppercase            Fix uppercase subtitles
   reverse-rtl              Reverse RTL directioned subtitles
+  remove-emoji             Remove emoji from subtitles
   help                     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -289,7 +289,7 @@ impl Action {
             movies = filter_unprocessed_movies(self.db_conn.clone(), movies, self.action.to_string()).await?;
             let after_len = movies.len();
             let difference = initial_len - after_len;
-            println!("Skipped {difference} already processed movies...");
+            println!("Skipped {difference} already {} processed movies...", self.action.to_string());
         }
         let num_movies: u64 = movies.len() as u64;
         if num_movies == 0 {
@@ -389,7 +389,7 @@ impl Action {
                 if difference > 0 {
                     self.log_info(
                         &pb_main,
-                        format!("Skipped {difference} already processed episodes..."),
+                        format!("Skipped {difference} already {} processed episodes...", self.action.to_string()),
                     );
                 } else {
                     self.log_info(&pb_main, "No previously processed episodes");

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -289,7 +289,7 @@ impl Action {
             movies = filter_unprocessed_movies(self.db_conn.clone(), movies, self.action.to_string()).await?;
             let after_len = movies.len();
             let difference = initial_len - after_len;
-            println!("Skipped {difference} already {} processed movies...", self.action.to_string());
+            println!("Skipped {difference} already {} processed movies...", self.action.to_cli_name());
         }
         let num_movies: u64 = movies.len() as u64;
         if num_movies == 0 {
@@ -389,7 +389,7 @@ impl Action {
                 if difference > 0 {
                     self.log_info(
                         &pb_main,
-                        format!("Skipped {difference} already {} processed episodes...", self.action.to_string()),
+                        format!("Skipped {difference} already {} processed episodes...", self.action.to_cli_name()),
                     );
                 } else {
                     self.log_info(&pb_main, "No previously processed episodes");

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -186,6 +186,7 @@ impl Action {
                             episode.sonarr_episode_id,
                             episode.title.clone(),
                             subtitle,
+                            self.action.to_string(),
                         )
                         .await;
                     }
@@ -243,6 +244,7 @@ impl Action {
                             movie.radarr_id,
                             movie.title.clone(),
                             subtitle,
+                            self.action.to_string(),
                         )
                         .await;
                     }
@@ -284,7 +286,7 @@ impl Action {
         let mut movies = response.data;
         if self.skip_processed {
             let initial_len = movies.len();
-            movies = filter_unprocessed_movies(self.db_conn.clone(), movies).await?;
+            movies = filter_unprocessed_movies(self.db_conn.clone(), movies, self.action.to_string()).await?;
             let after_len = movies.len();
             let difference = initial_len - after_len;
             println!("Skipped {difference} already processed movies...");
@@ -381,7 +383,7 @@ impl Action {
                     episodes.len()
                 );
                 let initial_len = episodes.len();
-                episodes = filter_unprocessed_episodes(self.db_conn.clone(), episodes).await?;
+                episodes = filter_unprocessed_episodes(self.db_conn.clone(), episodes, self.action.to_string()).await?;
                 let after_len = episodes.len();
                 let difference = initial_len - after_len;
                 if difference > 0 {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -140,6 +140,8 @@ pub enum ActionCommands {
     FixUppercase,
     /// Reverse RTL directioned subtitles
     ReverseRTL,
+    /// Remove emoji from subtitles
+    RemoveEmoji,
 }
 
 #[allow(clippy::to_string_trait_impl)]
@@ -153,6 +155,7 @@ impl ToString for ActionCommands {
             ActionCommands::RemoveStyleTags => "remove_tags".to_string(),
             ActionCommands::FixUppercase => "fix_uppercase".to_string(),
             ActionCommands::ReverseRTL => "reverse_rtl".to_string(),
+            ActionCommands::RemoveEmoji => "emoji".to_string(),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,6 +144,21 @@ pub enum ActionCommands {
     RemoveEmoji,
 }
 
+impl ActionCommands {
+    pub fn to_cli_name(&self) -> &'static str {
+        match self {
+            ActionCommands::Sync(_) => "sync",
+            ActionCommands::OCRFixes => "ocr-fixes",
+            ActionCommands::CommonFixes => "common-fixes",
+            ActionCommands::RemoveHearingImpaired => "remove-hearing-impaired",
+            ActionCommands::RemoveStyleTags => "remove-style-tags",
+            ActionCommands::FixUppercase => "fix-uppercase",
+            ActionCommands::ReverseRTL => "reverse-rtl",
+            ActionCommands::RemoveEmoji => "remove-emoji",
+        }
+    }
+}
+
 #[allow(clippy::to_string_trait_impl)]
 impl ToString for ActionCommands {
     fn to_string(&self) -> String {

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,36 +53,64 @@ pub async fn init_db(custom_path: Option<PathBuf>) -> Result<Arc<Mutex<Connectio
     Ok(Arc::new(Mutex::new(conn)))
 }
 
-fn create_tables(conn: &mut Connection) -> Result<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS processed_movie_subtitles (
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info(\"{}\")", table))?;
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>>>()?;
+    Ok(columns.iter().any(|c| c == column))
+}
+
+fn migrate_movie_table(conn: &mut Connection) -> Result<()> {
+    conn.execute_batch(
+        "BEGIN;
+        CREATE TABLE processed_movie_subtitles_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             radarr_id INTEGER NOT NULL,
             title TEXT NOT NULL,
             language_code TEXT NOT NULL,
             language_name TEXT NOT NULL,
             path TEXT,
+            action TEXT NOT NULL DEFAULT '',
             processed_at INTEGER NOT NULL,
-            UNIQUE(radarr_id, language_code)
-        )",
-        [],
-    )?;
+            UNIQUE(radarr_id, language_code, action)
+        );
+        INSERT INTO processed_movie_subtitles_new
+            (id, radarr_id, title, language_code, language_name, path, action, processed_at)
+        SELECT id, radarr_id, title, language_code, language_name, path, '', processed_at
+        FROM processed_movie_subtitles;
+        DROP TABLE processed_movie_subtitles;
+        ALTER TABLE processed_movie_subtitles_new RENAME TO processed_movie_subtitles;
+        COMMIT;",
+    )
+}
 
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS processed_episode_subtitles (
+fn migrate_episode_table(conn: &mut Connection) -> Result<()> {
+    conn.execute_batch(
+        "BEGIN;
+        CREATE TABLE processed_episode_subtitles_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             sonarr_episode_id INTEGER NOT NULL,
             title TEXT NOT NULL,
             language_code TEXT NOT NULL,
             language_name TEXT NOT NULL,
             path TEXT,
+            action TEXT NOT NULL DEFAULT '',
             processed_at INTEGER NOT NULL,
-            UNIQUE(sonarr_episode_id, language_code)
-        )",
-        [],
-    )?;
+            UNIQUE(sonarr_episode_id, language_code, action)
+        );
+        INSERT INTO processed_episode_subtitles_new
+            (id, sonarr_episode_id, title, language_code, language_name, path, action, processed_at)
+        SELECT id, sonarr_episode_id, title, language_code, language_name, path, '', processed_at
+        FROM processed_episode_subtitles;
+        DROP TABLE processed_episode_subtitles;
+        ALTER TABLE processed_episode_subtitles_new RENAME TO processed_episode_subtitles;
+        COMMIT;",
+    )
+}
 
-    let table_exists: bool = conn
+fn create_tables(conn: &mut Connection) -> Result<()> {
+    let movie_table_exists = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='processed_movie_subtitles'",
             [],
@@ -90,14 +118,7 @@ fn create_tables(conn: &mut Connection) -> Result<()> {
         )
         .unwrap_or(false);
 
-    if table_exists {
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_movie_radarr ON processed_movie_subtitles(radarr_id)",
-            [],
-        )?;
-    }
-
-    let table_exists: bool = conn
+    let episode_table_exists = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='processed_episode_subtitles'",
             [],
@@ -105,12 +126,71 @@ fn create_tables(conn: &mut Connection) -> Result<()> {
         )
         .unwrap_or(false);
 
-    if table_exists {
+    let mut migrated = false;
+
+    if movie_table_exists {
+        if !column_exists(conn, "processed_movie_subtitles", "action")? {
+            migrate_movie_table(conn)?;
+            migrated = true;
+        }
+    } else {
         conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_episode_sonarr ON processed_episode_subtitles(sonarr_episode_id)",
+            "CREATE TABLE IF NOT EXISTS processed_movie_subtitles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                radarr_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                language_code TEXT NOT NULL,
+                language_name TEXT NOT NULL,
+                path TEXT,
+                action TEXT NOT NULL DEFAULT '',
+                processed_at INTEGER NOT NULL,
+                UNIQUE(radarr_id, language_code, action)
+            )",
             [],
         )?;
     }
+
+    if episode_table_exists {
+        if !column_exists(conn, "processed_episode_subtitles", "action")? {
+            migrate_episode_table(conn)?;
+            migrated = true;
+        }
+    } else {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS processed_episode_subtitles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sonarr_episode_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                language_code TEXT NOT NULL,
+                language_name TEXT NOT NULL,
+                path TEXT,
+                action TEXT NOT NULL DEFAULT '',
+                processed_at INTEGER NOT NULL,
+                UNIQUE(sonarr_episode_id, language_code, action)
+            )",
+            [],
+        )?;
+    }
+
+    if migrated {
+        println!(
+            "\nWARNING: Database schema has been migrated to support per-action tracking.\n\
+             Existing records have been preserved with an empty action value and will NOT\n\
+             prevent re-processing under the new scheme. Each action (ocr-fixes, common-fixes,\n\
+             remove-emoji, etc.) is now tracked independently — you may need to re-run\n\
+             previous actions once to rebuild the per-action processed history.\n"
+        );
+    }
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_movie_radarr ON processed_movie_subtitles(radarr_id, action)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_episode_sonarr ON processed_episode_subtitles(sonarr_episode_id, action)",
+        [],
+    )?;
 
     Ok(())
 }
@@ -119,14 +199,15 @@ pub async fn is_movie_subtitle_processed(
     conn: Arc<Mutex<Connection>>,
     radarr_id: u32,
     language_code: String,
+    action: String,
 ) -> Result<bool> {
     tokio::task::spawn_blocking(move || {
         let conn = conn.blocking_lock();
         let mut stmt = conn.prepare(
-            "SELECT 1 FROM processed_movie_subtitles 
-             WHERE radarr_id = ?1 AND language_code = ?2",
+            "SELECT 1 FROM processed_movie_subtitles
+             WHERE radarr_id = ?1 AND language_code = ?2 AND action = ?3",
         )?;
-        stmt.exists(params![radarr_id, language_code])
+        stmt.exists(params![radarr_id, language_code, action])
     })
     .await
     .map_err(|e| rusqlite::Error::InvalidPath(e.to_string().into()))?
@@ -136,14 +217,15 @@ pub async fn is_episode_subtitle_processed(
     conn: Arc<Mutex<Connection>>,
     sonarr_episode_id: u32,
     language_code: String,
+    action: String,
 ) -> Result<bool> {
     tokio::task::spawn_blocking(move || {
         let conn = conn.blocking_lock();
         let mut stmt = conn.prepare(
-            "SELECT 1 FROM processed_episode_subtitles 
-             WHERE sonarr_episode_id = ?1 AND language_code = ?2",
+            "SELECT 1 FROM processed_episode_subtitles
+             WHERE sonarr_episode_id = ?1 AND language_code = ?2 AND action = ?3",
         )?;
-        stmt.exists(params![sonarr_episode_id, language_code])
+        stmt.exists(params![sonarr_episode_id, language_code, action])
     })
     .await
     .map_err(|e| rusqlite::Error::InvalidPath(e.to_string().into()))?
@@ -154,6 +236,7 @@ pub async fn mark_episode_subtitle_processed(
     sonarr_episode_id: u32,
     title: String,
     subtitle: Subtitle,
+    action: String,
 ) -> Result<bool> {
     let Some(language_code) = subtitle.audio_language_item.code2 else {
         return Ok(false);
@@ -167,16 +250,17 @@ pub async fn mark_episode_subtitle_processed(
             .as_secs() as i64;
 
         let rows = conn.execute(
-            "INSERT INTO processed_episode_subtitles 
-             (sonarr_episode_id, title, language_code, language_name, path, processed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(sonarr_episode_id, language_code) DO NOTHING",
+            "INSERT INTO processed_episode_subtitles
+             (sonarr_episode_id, title, language_code, language_name, path, action, processed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(sonarr_episode_id, language_code, action) DO NOTHING",
             params![
                 sonarr_episode_id,
                 title,
                 language_code,
                 subtitle.audio_language_item.name,
                 subtitle.path,
+                action,
                 now
             ],
         )?;
@@ -192,6 +276,7 @@ pub async fn mark_movie_subtitle_processed(
     radarr_id: u32,
     title: String,
     subtitle: Subtitle,
+    action: String,
 ) -> Result<bool> {
     let Some(language_code) = subtitle.audio_language_item.code2 else {
         return Ok(false);
@@ -205,16 +290,17 @@ pub async fn mark_movie_subtitle_processed(
             .as_secs() as i64;
 
         let rows = conn.execute(
-            "INSERT INTO processed_movie_subtitles 
-             (radarr_id, title, language_code, language_name, path, processed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(radarr_id, language_code) DO NOTHING",
+            "INSERT INTO processed_movie_subtitles
+             (radarr_id, title, language_code, language_name, path, action, processed_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(radarr_id, language_code, action) DO NOTHING",
             params![
                 radarr_id,
                 title,
                 language_code,
                 subtitle.audio_language_item.name,
                 subtitle.path,
+                action,
                 now
             ],
         )?;
@@ -228,6 +314,7 @@ pub async fn mark_movie_subtitle_processed(
 pub async fn filter_unprocessed_movies(
     conn: Arc<Mutex<Connection>>,
     movies: Vec<Movie>,
+    action: String,
 ) -> Result<Vec<Movie>> {
     if movies.is_empty() {
         return Ok(vec![]);
@@ -235,21 +322,23 @@ pub async fn filter_unprocessed_movies(
 
     let radarr_ids: Vec<u32> = movies.iter().map(|m| m.radarr_id).collect();
     let conn_clone = conn.clone();
+    let action_clone = action.clone();
 
     let processed_ids: HashSet<u32> = tokio::task::spawn_blocking(move || {
         let conn = conn_clone.blocking_lock();
         let placeholders = radarr_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let query = format!(
-            "SELECT DISTINCT radarr_id FROM processed_movie_subtitles 
-             WHERE radarr_id IN ({})",
+            "SELECT DISTINCT radarr_id FROM processed_movie_subtitles
+             WHERE radarr_id IN ({}) AND action = ?",
             placeholders
         );
 
         let mut stmt = conn.prepare(&query)?;
-        let params: Vec<&dyn rusqlite::ToSql> = radarr_ids
+        let mut params: Vec<&dyn rusqlite::ToSql> = radarr_ids
             .iter()
             .map(|id| id as &dyn rusqlite::ToSql)
             .collect();
+        params.push(&action_clone);
 
         let processed: HashSet<u32> =
             stmt.query_map(params.as_slice(), |row| row.get(0))?
@@ -270,7 +359,14 @@ pub async fn filter_unprocessed_movies(
         let mut has_unprocessed = false;
         for sub in &movie.subtitles {
             if let Some(ref code) = sub.audio_language_item.code2 {
-                if is_movie_subtitle_processed(conn.clone(), movie.radarr_id, code.clone()).await? {
+                if is_movie_subtitle_processed(
+                    conn.clone(),
+                    movie.radarr_id,
+                    code.clone(),
+                    action.clone(),
+                )
+                .await?
+                {
                     continue;
                 }
                 has_unprocessed = true;
@@ -289,6 +385,7 @@ pub async fn filter_unprocessed_movies(
 pub async fn filter_unprocessed_episodes(
     conn: Arc<Mutex<Connection>>,
     episodes: Vec<Episode>,
+    action: String,
 ) -> Result<Vec<Episode>> {
     if episodes.is_empty() {
         println!("No episodes to filter");
@@ -298,6 +395,7 @@ pub async fn filter_unprocessed_episodes(
     let episode_ids: Vec<u32> = episodes.iter().map(|e| e.sonarr_episode_id).collect();
     println!("Checking {} episodes in database", episode_ids.len());
     let conn_clone = conn.clone();
+    let action_clone = action.clone();
 
     let processed_ids: HashSet<u32> = tokio::task::spawn_blocking(move || {
         let conn = conn_clone.blocking_lock();
@@ -307,16 +405,17 @@ pub async fn filter_unprocessed_episodes(
             .collect::<Vec<_>>()
             .join(",");
         let query = format!(
-            "SELECT DISTINCT sonarr_episode_id FROM processed_episode_subtitles 
-             WHERE sonarr_episode_id IN ({})",
+            "SELECT DISTINCT sonarr_episode_id FROM processed_episode_subtitles
+             WHERE sonarr_episode_id IN ({}) AND action = ?",
             placeholders
         );
 
         let mut stmt = conn.prepare(&query)?;
-        let params: Vec<&dyn rusqlite::ToSql> = episode_ids
+        let mut params: Vec<&dyn rusqlite::ToSql> = episode_ids
             .iter()
             .map(|id| id as &dyn rusqlite::ToSql)
             .collect();
+        params.push(&action_clone);
 
         let processed: HashSet<u32> =
             stmt.query_map(params.as_slice(), |row| row.get(0))?
@@ -341,6 +440,7 @@ pub async fn filter_unprocessed_episodes(
                     conn.clone(),
                     episode.sonarr_episode_id,
                     code.clone(),
+                    action.clone(),
                 )
                 .await?
                 {


### PR DESCRIPTION
## Summary

Closes #61.

Note, this code was modified on top of https://github.com/mateoradman/bazarr-bulk/pull/60; if desired, I can rebase off main but have deployed and used both 60 (remove emojis) & 62 (skip processing + action) together to clean up my library this afternoon.

`--skip-processed` previously tracked processed subtitles without any reference to *which action* was run. Running `ocr-fixes` would mark every subtitle as processed, then running `common-fixes --skip-processed` would skip everything, treating a different action's history as its own.

This change makes the processed tracking per-action by including the action string as part of the unique key in both database tables.

- Adds an `action` column to `processed_movie_subtitles` and `processed_episode_subtitles`, incorporated into the `UNIQUE` constraint: `(radarr_id, language_code, action)` / `(sonarr_episode_id, language_code, action)`
- Updates all DB functions (`is_*_processed`, `mark_*_processed`, `filter_unprocessed_*`) to accept and filter by action
- Passes the Bazarr API action string at all DB call sites in `actions.rs` — no changes to the CLI interface
- Adds `to_cli_name()` method to `ActionCommands` returning the kebab-case CLI name (e.g. `ocr-fixes`, `common-fixes`) used in skip-processed log output, so messages directly match the commands users run
- Performs automatic schema migration on startup for existing databases: records are preserved with `action = ''`, indexes are rebuilt, and a one-time warning is printed (see Migration section below)
- Updates indexes to include `action` for query performance
- Documents the per-action behaviour in `README.md` and `DOCKER.md`

## Files Changed

| File | Change |
|------|--------|
| `src/db.rs` | Added `action` column + new UNIQUE constraints; `column_exists()` helper; `migrate_movie_table()` / `migrate_episode_table()` migration functions; startup migration warning; updated indexes; all 6 public DB functions updated with `action` parameter |
| `src/cli.rs` | Added `to_cli_name()` method to `ActionCommands` returning kebab-case CLI names |
| `src/actions.rs` | Pass action string to all four DB call sites; updated skip-processed log messages to use `to_cli_name()` (e.g. `Skipped 1945 already ocr-fixes processed movies...`) |
| `README.md` | Updated `--skip-processed` description; added multi-action usage example and migration note |
| `DOCKER.md` | Updated `--skip-processed` example comment |

## Migration: existing databases

SQLite does not support modifying `UNIQUE` constraints in-place. On first startup after this update, `create_tables()` detects whether the `action` column is missing (via `PRAGMA table_info`) and runs a transactional migration:

1. Creates replacement tables with the new schema
2. Copies all existing rows, setting `action = ''`
3. Drops the old tables and renames the new ones

**Consequence:** existing records get `action = ''`, which will never match a real action string (`OCR_fixes`, `common`, `emoji`, etc.). Those records become effectively inert for skip-processed purposes. Users will see this warning on first run:

```
WARNING: Database schema has been migrated to support per-action tracking.
Existing records have been preserved with an empty action value and will NOT
prevent re-processing under the new scheme. Each action (ocr-fixes, common-fixes,
remove-emoji, etc.) is now tracked independently — you may need to re-run
previous actions once to rebuild the per-action processed history.
```

This is the correct behaviour: old records have no meaningful action attached, so resetting them avoids silent false-skips.

## Usage

```bash
# These are now fully independent — neither skips the other's results
bb --config config.json movies --skip-processed ocr-fixes
bb --config config.json movies --skip-processed common-fixes
bb --config config.json movies --skip-processed remove-emoji
```

## Tested on my UnRaid instance, screenshots here:

1. First run (first ocr with new DB): command: ["--config", "/config/config.json", "movies", "--skip-processed", "ocr-fixes"]

Kickoff w/ warning message

<img width="556" height="321" alt="image" src="https://github.com/user-attachments/assets/0406a25b-a603-46c7-9fca-9218b8d5b786" />

DB entries with new action column

<img width="526" height="247" alt="image" src="https://github.com/user-attachments/assets/06c021ef-8a77-4bdd-8e39-6621d23d7fdf" />

2. Second run (second ocr): command: ["--config", "/config/config.json", "movies", "--skip-processed", "ocr-fixes"]

<img width="347" height="245" alt="image" src="https://github.com/user-attachments/assets/acfecf1b-633f-4eae-8df4-65768980e819" />

3. Third run (first remove style): command: ["--config", "/config/config.json", "movies", "--skip-processed", "remove-style-tags"]

<img width="481" height="295" alt="image" src="https://github.com/user-attachments/assets/5e57cb46-0385-4a4f-9ff3-066594ac5e87" />

DB entries with new action column

<img width="515" height="239" alt="image" src="https://github.com/user-attachments/assets/2be15595-ff5a-4ed2-9061-40e802a1fdc9" />

4. Fourth run (third ocr):  command: ["--config", "/config/config.json", "movies", "--skip-processed", "ocr-fixes"]

Confirmed to skip processing for that action type

<img width="347" height="159" alt="image" src="https://github.com/user-attachments/assets/fa73a371-a6aa-454f-b08d-1dbfd3fc8966" />

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!